### PR TITLE
convert documentation to reStructured Text

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,23 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Build documentation with MkDocs
+#mkdocs:
+#  configuration: mkdocs.yml
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.6
+  install:
+    - requirements: docs/requirements.txt

--- a/README.md
+++ b/README.md
@@ -14,21 +14,9 @@ Support: [![Discord](https://discordapp.com/api/guilds/656888365886734340/widget
 $ pip install ctyparser
 ```
 
+## API and CLI Documentation
 
-## API Reference
-
-*Coming soon. Refer to docstrings for now.*
-
-
-## CLI Usage
-
-**CLI is work in progress!**  
-Currently, only updating/creating a file named `cty.json` in the current working directory is supported.
-
-```none
-$ python3 -m ctyparser
-```
-
+See [read the docs url]()
 
 ## Copyright
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A CTY.DAT parser for modern amateur radio programs.
 
 Support: [![Discord](https://discordapp.com/api/guilds/656888365886734340/widget.png?style=shield)](https://discord.gg/SwyjdDN)
 
-[![PyPI](https://img.shields.io/pypi/v/ctyparser)](https://pypi.org/project/ctyparser/) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/ctyparser) ![PyPI - License](https://img.shields.io/pypi/l/ctyparser)
+[![PyPI](https://img.shields.io/pypi/v/ctyparser)](https://pypi.org/project/ctyparser/) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/ctyparser) ![PyPI - License](https://img.shields.io/pypi/l/ctyparser) [![Documentation Status](https://readthedocs.org/projects/ctyparser/badge/?version=latest)](https://ctyparser.readthedocs.io/en/latest/?badge=latest)
 
 ## Installation
 
@@ -16,7 +16,7 @@ $ pip install ctyparser
 
 ## API and CLI Documentation
 
-See [read the docs url]()
+Documentation is available on [ReadTheDocs](https://ctyparser.readthedocs.io/).
 
 ## Copyright
 

--- a/ctyparser/bigcty.py
+++ b/ctyparser/bigcty.py
@@ -33,6 +33,7 @@ class BigCty(collections.abc.Mapping):
     :type file_path: str or os.PathLike, optional
 
     :var version: the datestamp of the data, ``YYYYMMDD`` format.
+    :vartype version: str
     """
     regex_version_entry = re.compile(r"VER(\d{8})")
     regex_feed_date = re.compile(r'(\d{2}-\w+-\d{4})')
@@ -48,8 +49,6 @@ class BigCty(collections.abc.Mapping):
                                  (?:~(?P<tz>[+-]?\d+(?:\.\d+)?)~)?""", re.X)
 
     def __init__(self, file_path: Union[str, os.PathLike, None] = None):
-        """Can be initialised with data by passing the path to a valid ``cty.json`` file to the constructor.
-        """
         self._data: dict = {}
         self.version = ""
 
@@ -191,9 +190,6 @@ class BigCty(collections.abc.Mapping):
     # --- Standard methods we should all implement ---
     # str(): Simply return what it would be for the underlaying dict
     def __str__(self):
-        """
-        :return: str(data)
-        """
         return str(self._data)
 
     # repr(): Class name, instance ID, and last_updated

--- a/ctyparser/bigcty.py
+++ b/ctyparser/bigcty.py
@@ -26,28 +26,13 @@ default_feed = "http://www.country-files.com/category/big-cty/feed/"
 
 
 class BigCty(collections.abc.Mapping):
-    """BigCty
-    ------
+    """Class representing a BigCTY dataset.
+    Can be initialised with data by passing the path to a valid ``cty.json`` file to the constructor.
 
-    Class representing a BigCTY dataset.
-    Can be initialised with data by passing the path
-    to a valid 'cty.json' file to the constructor.
+    :param file_path: Location of the ``cty.json`` file to load.
+    :type file_path: str or os.PathLike, optional
 
-    Methods:
-
-    `.load()` a 'cty.json' file. Overwrites the internal data.
-
-    `.dump()` the data to a 'cty.json' file.
-
-    `.import_dat()` directly import data from a 'cty.dat' file.
-
-    `.update()` the data from the internet.
-
-    Attributes:
-
-    `.version`: the datestamp of the data, YYYYMMDD format.
-
-    `.formatted_version`: a more human friendly representation of the datestamp.
+    :var version: the datestamp of the data, ``YYYYMMDD`` format.
     """
     regex_version_entry = re.compile(r"VER(\d{8})")
     regex_feed_date = re.compile(r'(\d{2}-\w+-\d{4})')
@@ -63,6 +48,8 @@ class BigCty(collections.abc.Mapping):
                                  (?:~(?P<tz>[+-]?\d+(?:\.\d+)?)~)?""", re.X)
 
     def __init__(self, file_path: Union[str, os.PathLike, None] = None):
+        """Can be initialised with data by passing the path to a valid ``cty.json`` file to the constructor.
+        """
         self._data: dict = {}
         self.version = ""
 
@@ -70,10 +57,11 @@ class BigCty(collections.abc.Mapping):
             self.load(file_path)
 
     def load(self, cty_file: Union[str, os.PathLike]) -> None:
-        """Loads a cty.json file into the instance.
+        """Loads a ``cty.json`` file into the instance.
 
-        Args:
-            cty_file (str or os.PathLike): Path to the file to load.
+        :param cty_file: Path to the file to load.
+        :type cty_file: str or os.PathLike
+        :return: None
         """
         cty_file = pathlib.Path(cty_file)
         with cty_file.open("r") as file:
@@ -82,10 +70,11 @@ class BigCty(collections.abc.Mapping):
             self._data = ctyjson
 
     def dump(self, cty_file: Union[str, os.PathLike]) -> None:
-        """Dumps the data of the instance to a cty.json file.
+        """Dumps the data of the instance to a ``cty.json`` file.
 
-        Args:
-            cty_file (str or os.PathLike): Path to the file to dump to.
+        :param cty_file: Path to the file to dump to.
+        :type cty_file: str or os.PathLike
+        :return: None
         """
         cty_file = pathlib.Path(cty_file)
         datadump = self._data.copy()
@@ -94,10 +83,11 @@ class BigCty(collections.abc.Mapping):
             json.dump(datadump, file)
 
     def import_dat(self, dat_file: Union[str, os.PathLike]) -> None:
-        """Imports CTY data from a cty.dat file.
+        """Imports CTY data from a ``CTY.DAT`` file.
 
-        Args:
-            dat_file (str or os.PathLike): Path to the file to import.
+        :param dat_file: Path to the file to import.
+        :type dat_file: str or os.PathLike
+        :return: None
         """
         dat_file = pathlib.Path(dat_file)
         with dat_file.open("r") as file:
@@ -149,8 +139,9 @@ class BigCty(collections.abc.Mapping):
     def update(self) -> bool:
         """Upates the instance's data from the feed.
 
-        Returns:
-            True if an update was done, otherwise False.
+        :raises Exception: If there is no date in the feed.
+        :return: ``True`` if an update was done, otherwise ``False``.
+        :rtype: bool
         """
         with requests.Session() as session:
             feed = session.get(default_feed)
@@ -178,7 +169,7 @@ class BigCty(collections.abc.Mapping):
     @property
     def formatted_version(self) -> str:
         """Formatted representation of the version/date of the current BigCTY data.
-        "0000-00-00" if invalid datestamp."""
+        ``0000-00-00`` if invalid datestamp."""
         try:
             return datetime.strptime(self.version, "%Y%m%d").strftime("%Y-%m-%d")
         except ValueError:
@@ -197,6 +188,9 @@ class BigCty(collections.abc.Mapping):
     # --- Standard methods we should all implement ---
     # str(): Simply return what it would be for the underlaying dict
     def __str__(self):
+        """
+        :return: str(data)
+        """
         return str(self._data)
 
     # repr(): Class name, instance ID, and last_updated

--- a/ctyparser/bigcty.py
+++ b/ctyparser/bigcty.py
@@ -169,7 +169,10 @@ class BigCty(collections.abc.Mapping):
     @property
     def formatted_version(self) -> str:
         """Formatted representation of the version/date of the current BigCTY data.
-        ``0000-00-00`` if invalid datestamp."""
+
+        :getter: Returns version in ``YYYY-MM-DD`` format, or ``0000-00-00`` (if invalid date)
+        :type: str
+        """
         try:
             return datetime.strptime(self.version, "%Y%m%d").strftime("%Y-%m-%d")
         except ValueError:

--- a/devrequirements.txt
+++ b/devrequirements.txt
@@ -2,6 +2,7 @@
 flake8
 mypy
 twine
+sphinx
 
 # Dependencies
 feedparser

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,3 +54,5 @@ html_theme = 'alabaster'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+master_doc = 'index'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,7 +60,7 @@ master_doc = 'index'
 # -- Options for autodoc -----------------------------------------------------
 
 autodoc_default_options = {
-    "members": True,
+    "members": None,
     "member-order": "bysource",
-    "ignore-module-all": True,
+    "ignore-module-all": None,
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,3 +56,11 @@ html_theme = 'alabaster'
 html_static_path = ['_static']
 
 master_doc = 'index'
+
+# -- Options for autodoc -----------------------------------------------------
+
+autodoc_default_options = {
+    "members": True,
+    "member-order": "bysource",
+    "ignore-module-all": True,
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,56 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'ctyparser'
+copyright = '2020, classabbyamp, 0x5c'
+author = 'classabbyamp, 0x5c'
+
+# The full version, including alpha/beta/rc tags
+release = '2.0.0.post1'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'sphinx.ext.autodoc'
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,6 +35,6 @@ CLI Usage
 
 .. note:: CLI is a work in progress!
 
-Currently, only updating/creating a file named ``cty.json`` in the current working directory is supported.::
+Currently, only updating/creating a file named ``cty.json`` in the current working directory is supported::
 
     $ python3 -m ctyparser

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,10 +3,6 @@ ctyparser
 
 A ``CTY.DAT`` parser for modern amateur radio programs.
 
-.. toctree::
-   :maxdepth: 2
-   :caption: Contents:
-
 Installation
 ------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,40 @@
+ctyparser
+=========
+
+A ``CTY.DAT`` parser for modern amateur radio programs.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+Installation
+------------
+
+``ctyparser`` requires Python 3.6 at minimum. Install by running::
+
+    $ pip install ctyparser
+
+License
+-------
+
+Copyright 2020 classabbyamp, 0x5c
+
+Released under the MIT License. See ``LICENSE`` for the full license text.
+
+API
+---
+
+.. module:: ctyparser
+
+.. autoclass:: BigCty
+    :members:
+
+
+CLI Usage
+---------
+
+.. note:: CLI is a work in progress!
+
+Currently, only updating/creating a file named ``cty.json`` in the current working directory is supported.::
+
+    $ python3 -m ctyparser

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,8 +23,6 @@ API
 .. module:: ctyparser
 
 .. autoclass:: BigCty
-    :members:
-
 
 CLI Usage
 ---------

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+feedparser
+requests


### PR DESCRIPTION
can be generated by doing `make html` in the docs directory.

Fixes #32 

### Generated documentation
![image](https://user-images.githubusercontent.com/5366828/80919996-f9fdc980-8d3a-11ea-8696-38eb295f4a84.png)
