### PR TITLE
Add primary prefix to json

### DIFF
--- a/ctyparser/bigcty.py
+++ b/ctyparser/bigcty.py
@@ -109,7 +109,8 @@ class BigCty(collections.abc.Mapping):
                     cty_dict[segments[7]] = {'entity': segments[0], 'cq': int(segments[1]),
                                              'itu': int(segments[2]), 'continent': segments[3],
                                              'lat': float(segments[4]), 'long': float(segments[5]),
-                                             'tz': -1*float(segments[6]), 'len': len(segments[7])}
+                                             'tz': -1*float(segments[6]), 'len': len(segments[7]),
+                                             'main': segments[7]}
                     last = segments[7]
 
                 elif line != '' and line[0].isspace():

--- a/ctyparser/bigcty.py
+++ b/ctyparser/bigcty.py
@@ -110,7 +110,7 @@ class BigCty(collections.abc.Mapping):
                                              'itu': int(segments[2]), 'continent': segments[3],
                                              'lat': float(segments[4]), 'long': float(segments[5]),
                                              'tz': -1*float(segments[6]), 'len': len(segments[7]),
-                                             'main': segments[7]}
+                                             'primary_pfx': segments[7]}
                     last = segments[7]
 
                 elif line != '' and line[0].isspace():


### PR DESCRIPTION
Add main field to get the main prefix for a searched prefix

### Description
I added a field 'main' to the dict to get the main prefix of any prefix. So main of e.g.  '2E' is 'G'.

### Type of change
- New feature 

### How has this been tested?
Cherry picked manual check of 3 prefixes

### Checklist
- [ ] Issue exists for PR
- [ ] Code reviewed by the author
- [ ] Code documented (comments or other documentation)
- [ ] Changes tested
- [ ] All tests pass (see [`DEVELOPING.md`][0], if it exists)
- [ ] [`CHANGELOG.md`][1] updated if needed
- [ ] Informative commit messages
- [ ] Descriptive PR title

[0]: /DEVELOPING.md
[1]: /CHANGELOG.md
